### PR TITLE
Add configurable denoising loss functions to LitS4CombinedModel

### DIFF
--- a/configs/config_combined_denoise_regression.yaml
+++ b/configs/config_combined_denoise_regression.yaml
@@ -81,7 +81,19 @@ model:
     #   start_value: 1.0
     #   end_value: 0.1
 
-    loss: 'MSELoss'        # regression loss (denoising always uses MSELoss)
+    # ── Denoising loss ────────────────────────────────────────────────────
+    # Options: 'MSELoss' | 'HuberLoss' | 'WeightedMSELoss' | 'MixtureMSESpectralLoss'
+    # (GaussianNLLLoss is not supported for sequence targets)
+    denoising_loss: 'MSELoss'
+    # denoising_huber_delta: 1.0        # used when denoising_loss: 'HuberLoss'
+    # denoising_spectral_alpha: 0.5     # used when denoising_loss: 'MixtureMSESpectralLoss'
+    # denoising_weights: null           # used when denoising_loss: 'WeightedMSELoss'
+
+    # ── Regression loss ───────────────────────────────────────────────────
+    # Options: 'MSELoss' | 'HuberLoss' | 'WeightedMSELoss' | 'GaussianNLLLoss' | 'MixtureMSESpectralLoss'
+    loss: 'MSELoss'
+    # huber_delta: 1.0                  # used when loss: 'HuberLoss'
+    # spectral_alpha: 0.5               # used when loss: 'MixtureMSESpectralLoss'
     learning_rate: 1e-3
     lr_schedule_type: reduce_on_plateau
     gamma: 0.25

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -235,7 +235,7 @@ class LitS4CombinedModel(BaseLightningModule):
 
     The total loss is a weighted sum::
 
-        loss = lambda_denoise * MSE(x_denoised, x_clean)
+        loss = lambda_denoise * denoising_loss(x_denoised, x_clean)
              + lambda_regress * regression_loss(y_pred, y)
 
     Both lambdas can be scheduled over epochs via
@@ -256,6 +256,15 @@ class LitS4CombinedModel(BaseLightningModule):
 
     If no schedule dict is provided the corresponding lambda stays constant.
     Both sub-losses and the current lambda values are logged every epoch.
+
+    Denoising loss options (``denoising_loss``):
+      - ``'MSELoss'``               – mean squared error (default)
+      - ``'HuberLoss'``             – Huber loss; set ``denoising_huber_delta``
+      - ``'WeightedMSELoss'``       – per-feature weighted MSE; set ``denoising_weights``
+      - ``'MixtureMSESpectralLoss'``– time + frequency domain MSE mix; set ``denoising_spectral_alpha``
+
+    Regression loss options (``loss``) are the same as :class:`BaseLightningModule`,
+    including ``'GaussianNLLLoss'``.
     """
 
     def __init__(self,
@@ -264,11 +273,26 @@ class LitS4CombinedModel(BaseLightningModule):
                  lambda_denoise_schedule: dict = None,
                  lambda_regress_schedule: dict = None,
                  trainer_max_epochs: int = 100,
+                 denoising_loss: str = 'MSELoss',
+                 denoising_weights=None,
+                 denoising_huber_delta: float = 1.0,
+                 denoising_spectral_alpha: float = 0.5,
                  **kwargs):
         super().__init__(trainer_max_epochs=trainer_max_epochs, **kwargs)
         self.lambda_denoise = lambda_denoise
         self.lambda_regress = lambda_regress
-        self.denoising_criterion = nn.MSELoss()
+
+        if denoising_loss == 'MSELoss':
+            self.denoising_criterion = nn.MSELoss()
+        elif denoising_loss == 'HuberLoss':
+            self.denoising_criterion = nn.HuberLoss(delta=denoising_huber_delta)
+        elif denoising_loss == 'WeightedMSELoss':
+            self.denoising_criterion = WeightedMSELoss(weights=denoising_weights)
+        elif denoising_loss == 'MixtureMSESpectralLoss':
+            self.denoising_criterion = MixtureMSESpectralLoss(alpha=denoising_spectral_alpha)
+        else:
+            raise ValueError(f'Unknown denoising loss function {denoising_loss!r}. '
+                             f'GaussianNLLLoss is not supported for sequence targets.')
 
         def _make_scheduler(schedule_cfg, default_value):
             if schedule_cfg is None:


### PR DESCRIPTION
## Summary
Extended the `LitS4CombinedModel` to support multiple denoising loss functions beyond the hardcoded MSELoss, while maintaining backward compatibility with the default MSELoss behavior.

## Key Changes
- **Added denoising loss flexibility**: Introduced `denoising_loss` parameter to `LitS4CombinedModel.__init__()` with support for:
  - `'MSELoss'` (default)
  - `'HuberLoss'` with configurable `denoising_huber_delta`
  - `'WeightedMSELoss'` with configurable `denoising_weights`
  - `'MixtureMSESpectralLoss'` with configurable `denoising_spectral_alpha`

- **Replaced hardcoded loss**: Changed from `self.denoising_criterion = nn.MSELoss()` to a conditional factory pattern that instantiates the appropriate loss function based on the parameter

- **Added validation**: Implemented error handling with informative message for unsupported loss types, explicitly noting that `GaussianNLLLoss` is not supported for sequence targets

- **Updated documentation**: 
  - Enhanced docstring with denoising and regression loss options
  - Added configuration examples in `config_combined_denoise_regression.yaml` showing all available loss options and their parameters
  - Clarified the distinction between denoising loss (for sequence targets) and regression loss (which supports additional options like `GaussianNLLLoss`)

## Implementation Details
- Maintains backward compatibility: existing code using the model without specifying `denoising_loss` will default to `'MSELoss'`
- Configuration file now clearly separates denoising loss and regression loss sections with commented examples for optional parameters
- Loss function instantiation happens in `__init__`, avoiding repeated object creation during training

https://claude.ai/code/session_01KGCWNg3NgZHpkGDs7yuo83