### PR TITLE
Add freeze_denoiser option for training regressor with frozen denoiser

### DIFF
--- a/configs/config_frozen_denoiser.yaml
+++ b/configs/config_frozen_denoiser.yaml
@@ -1,0 +1,96 @@
+# Frozen-denoiser configuration
+# ─────────────────────────────────────────────────────────────────────
+# Load a pretrained combined model, freeze the denoiser, and train
+# only the regression head.
+#
+# Usage:
+#   python cli.py fit --config configs/config_frozen_denoiser.yaml
+#
+# Make sure to set:
+#   1. encoder.init_args.pretrained_ckpt_path  – path to a LitS4CombinedModel
+#      checkpoint (.ckpt) produced by a previous training run.
+#      (Alternatively, use denoiser_ckpt_path to load from a standalone
+#       LitS4DenoisingModel checkpoint.)
+#   2. data.init_args.data_dir – path to your HDF5 data directory.
+
+trainer:
+  accelerator: auto
+  default_root_dir: 'runs/frozen_denoiser/'
+  callbacks:
+    - class_path: lightning.pytorch.callbacks.ModelCheckpoint
+      init_args:
+        monitor: val/loss
+        mode: min
+        save_top_k: 1
+        save_last: true
+    - class_path: lightning.pytorch.callbacks.EarlyStopping
+      init_args:
+        monitor: val/loss
+        patience: 10
+        mode: min
+  logger:
+    class_path: lightning.pytorch.loggers.WandbLogger
+  log_every_n_steps: 1
+  max_epochs: 80
+
+data:
+  class_path: src.data.data.LitCombinedDataModule
+  init_args:
+    inputs: ['output_ts_I', 'output_ts_Q']
+    variables: ['energy_eV', 'pitch_angle_deg']
+    observables: ['avg_axial_frequency_Hz', 'avg_carrier_frequency_Hz', 'radius_m']
+    data_dir: '/path/to/data/'   # <-- update to your HDF5 directory
+    batch_size: 128
+    num_workers: 4
+    cutoff: 8192
+    noise_const: 1.0
+    apply_filter: false
+    use_curriculum_learning: false
+
+model:
+  class_path: src.models.model.LitS4CombinedModel
+  init_args:
+    trainer_max_epochs: 80
+
+    # ── Freeze the denoiser ───────────────────────────────────────────
+    freeze_denoiser: true
+
+    # Only regression loss matters (denoiser gradients are blocked),
+    # but denoising loss is still logged for monitoring.
+    lambda_denoise: 0.0
+    lambda_regress: 1.0
+
+    denoising_loss: 'MSELoss'
+    loss: 'MSELoss'
+
+    learning_rate: 1e-3
+    lr_schedule_type: reduce_on_plateau
+    gamma: 0.25
+    lr_patience: 5
+    threshold: 1e-3
+    lr_min: 1e-6
+
+    encoder:
+      class_path: src.models.networks.S4DCombinedModel
+      init_args:
+        d_input: 2
+        d_output: 2
+        # Denoiser (frozen – weights loaded from pretrained checkpoint)
+        denoiser_d_model: 128
+        denoiser_n_layers: 6
+        denoiser_dropout: 0.0
+        denoiser_prenorm: false
+        denoiser_gradient_checkpointing: false
+        # Regressor (trainable)
+        regressor_d_model: 128
+        regressor_n_layers: 6
+        regressor_dropout: 0.0
+        regressor_prenorm: false
+        regressor_fc_hidden: [64, 32]
+        regressor_gradient_checkpointing: false
+        # ── Pretrained checkpoint ─────────────────────────────────────
+        # Full combined-model checkpoint (loads both denoiser + regressor):
+        pretrained_ckpt_path: null   # <-- set to your .ckpt path
+        # Or load sub-networks individually:
+        denoiser_ckpt_path: null
+        regressor_ckpt_path: null

--- a/src/models/model.py
+++ b/src/models/model.py
@@ -265,6 +265,20 @@ class LitS4CombinedModel(BaseLightningModule):
 
     Regression loss options (``loss``) are the same as :class:`BaseLightningModule`,
     including ``'GaussianNLLLoss'``.
+
+    Frozen denoiser
+    ~~~~~~~~~~~~~~~
+    Set ``freeze_denoiser=True`` to freeze the denoiser weights and only train
+    the regressor.  Combine with ``pretrained_ckpt_path`` (on the encoder) or
+    ``denoiser_ckpt_path`` to load pre-trained denoiser weights first::
+
+        freeze_denoiser: true
+        encoder:
+          init_args:
+            pretrained_ckpt_path: 'runs/combined_run/checkpoints/best.ckpt'
+
+    The denoiser is kept in eval mode throughout training so that dropout
+    layers remain inactive.
     """
 
     def __init__(self,
@@ -277,10 +291,17 @@ class LitS4CombinedModel(BaseLightningModule):
                  denoising_weights=None,
                  denoising_huber_delta: float = 1.0,
                  denoising_spectral_alpha: float = 0.5,
+                 freeze_denoiser: bool = False,
                  **kwargs):
         super().__init__(trainer_max_epochs=trainer_max_epochs, **kwargs)
         self.lambda_denoise = lambda_denoise
         self.lambda_regress = lambda_regress
+        self.freeze_denoiser = freeze_denoiser
+
+        if self.freeze_denoiser:
+            self.encoder.denoiser.eval()
+            for param in self.encoder.denoiser.parameters():
+                param.requires_grad = False
 
         if denoising_loss == 'MSELoss':
             self.denoising_criterion = nn.MSELoss()
@@ -308,6 +329,13 @@ class LitS4CombinedModel(BaseLightningModule):
         self.regress_lambda_scheduler = _make_scheduler(lambda_regress_schedule, lambda_regress)
 
         self.save_hyperparameters()
+
+    def train(self, mode=True):
+        super().train(mode)
+        # Keep the denoiser in eval mode so dropout stays off
+        if self.freeze_denoiser:
+            self.encoder.denoiser.eval()
+        return self
 
     def on_train_epoch_start(self):
         # Update lambdas from their schedules, then call parent for curriculum noise

--- a/src/models/networks.py
+++ b/src/models/networks.py
@@ -469,7 +469,8 @@ class S4DCombinedModel(nn.Module):
                  regressor_fc_hidden=[64, 32],
                  regressor_gradient_checkpointing=False,
                  denoiser_ckpt_path=None,
-                 regressor_ckpt_path=None):
+                 regressor_ckpt_path=None,
+                 pretrained_ckpt_path=None):
         super().__init__()
 
         self.denoiser = S4DSeq2SeqModel(
@@ -493,6 +494,8 @@ class S4DCombinedModel(nn.Module):
             gradient_checkpointing=regressor_gradient_checkpointing,
         )
 
+        if pretrained_ckpt_path is not None:
+            self._load_pretrained(pretrained_ckpt_path)
         if denoiser_ckpt_path is not None:
             self._load_weights(self.denoiser, denoiser_ckpt_path, prefix='encoder.')
         if regressor_ckpt_path is not None:
@@ -508,6 +511,22 @@ class S4DCombinedModel(nn.Module):
             if k.startswith(prefix)
         }
         missing, unexpected = module.load_state_dict(sub_state, strict=False)
+
+    def _load_pretrained(self, ckpt_path):
+        """Load a full pretrained combined-model checkpoint.
+
+        Expects a Lightning checkpoint whose ``state_dict`` keys start with
+        ``encoder.denoiser.*`` and ``encoder.regressor.*``.
+        """
+        ckpt = torch.load(ckpt_path, map_location='cpu')
+        state_dict = ckpt.get('state_dict', ckpt)
+        prefix = 'encoder.'
+        sub_state = {
+            k[len(prefix):]: v
+            for k, v in state_dict.items()
+            if k.startswith(prefix)
+        }
+        missing, unexpected = self.load_state_dict(sub_state, strict=False)
 
     def forward(self, x):
         """


### PR DESCRIPTION
- Add `pretrained_ckpt_path` to S4DCombinedModel to load a full combined-model checkpoint (both denoiser + regressor weights from a single .ckpt)
- Add `freeze_denoiser` flag to LitS4CombinedModel that freezes all denoiser parameters and keeps it in eval mode throughout training
- Override train() to ensure denoiser stays in eval mode when Lightning toggles
- Add example config (config_frozen_denoiser.yaml)

https://claude.ai/code/session_01Jd1q7r4tRRbxxKyoLBKFN8